### PR TITLE
add mac keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,16 +78,19 @@
         "keybindings": [
             {
                 "key": "ctrl+c",
+                "mac": "cmd+c",
                 "when": "editorFocus",
                 "command": "clipring.copyToRing"
             },
             {
                 "key": "ctrl+x",
+                "mac": "cmd+x",
                 "when": "editorFocus",
                 "command": "clipring.cutToRing"
             },
             {
                 "key": "ctrl+shift+v",
+                "mac": "cmd+shift+v",
                 "when": "editorFocus",
                 "command": "clipring.pasteRingItem"
             }


### PR DESCRIPTION
add mac keybindings. ([vscode documentation](https://code.visualstudio.com/docs/extensionAPI/extension-points#_contributeskeybindings))

## Before the fix

Without this keybinding, I can only copy the last item into ring with `cmd + c`: (note `cmd + y` is my custom keybinding for `clipring.pasteRingItem`):
![ring-cmd-c](https://user-images.githubusercontent.com/6076919/28362847-a7a7389a-6cb0-11e7-8aa0-9a79cd048cbb.gif)

> The `4444` is not copied into ring items.


But it works as expected if I use `ctrl + c`:
![ring-ctrl-c](https://user-images.githubusercontent.com/6076919/28362851-adf1ec7c-6cb0-11e7-9ca2-23995f117e36.gif)


## After the fix

![ring-cmd-c-fixed](https://user-images.githubusercontent.com/6076919/28363431-25515076-6cb3-11e7-93e8-519b88913bed.gif)
